### PR TITLE
Catch crash when trying to upload a not available video file

### DIFF
--- a/youtube2peertube.py
+++ b/youtube2peertube.py
@@ -166,22 +166,25 @@ def upload_to_pt(dl_dir, channel_conf, queue_item, access_token, thumb_extension
     # MultipartEncoder does not support list refer
     # https://github.com/requests/toolbelt/issues/190 and
     # https://github.com/requests/toolbelt/issues/205
-    fields = [
-        ("name", queue_item["title"]),
-        ("licence", "1"),
-        ("description", description),
-        ("nsfw", channel_conf["nsfw"]),
-        ("channelId", channel_id),
-        ("originallyPublishedAt", queue_item["published"]),
-        ("category", channel_conf["pt_channel_category"]),
-        ("language", channel_conf["default_lang"]),
-        ("privacy", str(channel_conf["pt_privacy"])),
-        ("commentsEnabled", channel_conf["comments_enabled"]),
-        ("videofile", get_file(video_file)),
-        ("thumbnailfile", get_file(thumb_file)),
-        ("previewfile", get_file(thumb_file)),
-        ("waitTranscoding", 'false')
-    ]
+    try:
+        fields = [
+            ("name", queue_item["title"]),
+            ("licence", "1"),
+            ("description", description),
+            ("nsfw", channel_conf["nsfw"]),
+            ("channelId", channel_id),
+            ("originallyPublishedAt", queue_item["published"]),
+            ("category", channel_conf["pt_channel_category"]),
+            ("language", channel_conf["default_lang"]),
+            ("privacy", str(channel_conf["pt_privacy"])),
+            ("commentsEnabled", channel_conf["comments_enabled"]),
+            ("videofile", get_file(video_file)),
+            ("thumbnailfile", get_file(thumb_file)),
+            ("previewfile", get_file(thumb_file)),
+            ("waitTranscoding", 'false')
+        ]
+    except:
+        return
 
     if channel_conf["pt_tags"] != "":
         fields.append(("tags", "[" + channel_conf["pt_tags"] + "]"))


### PR DESCRIPTION
This happens for example when a Live Stream is scheduled on a
YT-Channel. In this case the download of the video file is not possible
and therefore the attempt to upload leads to a crash.